### PR TITLE
Use pysodium instead of argon_cffi for argon2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     env: TOXENV=py27-devel
   - python: 2.6
     env: TOXENV=py26
-before_install: sudo apt-get update && sudo apt-get install libsodium-dev
+before_install: sudo apt-get update && sudo apt-get install libsodium
 install: pip install tox
 script: tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     env: TOXENV=py27-devel
   - python: 2.6
     env: TOXENV=py26
-before_install: sudo apt-get update && sudo apt-cache search libsodium
+before_install: sudo apt-get update && sudo apt-get install libsodium18
 install: pip install tox
 script: tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     env: TOXENV=py27-devel
   - python: 2.6
     env: TOXENV=py26
-before_install: sudo apt-get update && sudo apt-get install libsodium
+before_install: sudo apt-get update && sudo apt-cache search libsodium
 install: pip install tox
 script: tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     env: TOXENV=py27-devel
   - python: 2.6
     env: TOXENV=py26
+before_install: apt-get update && apt-get install libsodium-dev
 install: pip install tox
 script: tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     env: TOXENV=py27-devel
   - python: 2.6
     env: TOXENV=py26
-before_install: apt-get update && apt-get install libsodium-dev
+before_install: sudo apt-get update && sudo apt-get install libsodium-dev
 install: pip install tox
 script: tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,11 @@ matrix:
     env: TOXENV=py27-devel
   - python: 2.6
     env: TOXENV=py26
-before_install: sudo apt-get update && sudo apt-get install libsodium18
+before_install:
+    - sudo add-apt-repository ppa:chris-lea/libsodium;
+    - sudo echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" >> /etc/apt/sources.list
+    - sudo echo "deb-src http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" >> /etc/apt/sources.list
+    - sudo apt-get update && sudo apt-get install libsodium-dev
 install: pip install tox
 script: tox
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
     env: TOXENV=py26
 before_install:
     - sudo add-apt-repository ppa:chris-lea/libsodium -y 
-    - sudo echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" >> /etc/apt/sources.list
-    - sudo echo "deb-src http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" >> /etc/apt/sources.list
+    - echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
+    - echo "deb-src http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null
     - sudo apt-get update && sudo apt-get install libsodium-dev
 install: pip install tox
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   - python: 2.6
     env: TOXENV=py26
 before_install:
-    - sudo add-apt-repository ppa:chris-lea/libsodium;
+    - sudo add-apt-repository ppa:chris-lea/libsodium -y
     - sudo echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" >> /etc/apt/sources.list
     - sudo echo "deb-src http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" >> /etc/apt/sources.list
     - sudo apt-get update && sudo apt-get install libsodium-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     env: TOXENV=py27-devel
   - python: 2.6
     env: TOXENV=py26
+dist: xenial
 before_install:
     - sudo add-apt-repository ppa:chris-lea/libsodium -y 
     - echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" | sudo tee -a /etc/apt/sources.list > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   - python: 2.6
     env: TOXENV=py26
 before_install:
-    - sudo add-apt-repository ppa:chris-lea/libsodium -y
+    - sudo add-apt-repository ppa:chris-lea/libsodium -y 
     - sudo echo "deb http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" >> /etc/apt/sources.list
     - sudo echo "deb-src http://ppa.launchpad.net/chris-lea/libsodium/ubuntu trusty main" >> /etc/apt/sources.list
     - sudo apt-get update && sudo apt-get install libsodium-dev

--- a/ctf/core.py
+++ b/ctf/core.py
@@ -113,7 +113,7 @@ def login(username, password):
     if user and crypto_pwhash_str_verify(user.password, want_bytes(password)):
         return user
     else:
-        raise CtfException('Incorrect username or password.')
+        raise CtfException('Incorrect password.')
 
 
 def create_team(user, name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ itsdangerous==0.24
 Jinja2==2.9.6
 MarkupSafe==1.0
 packaging==16.8
-pkg-resources==0.0.0
 pycparser==2.17
 pyparsing==2.2.0
 pysodium==0.6.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 appdirs==1.4.3
-argon2-cffi==16.3.0
-cffi==1.10.0
 click==6.7
 filelock==2.0.8
 Flask==0.12.1
@@ -10,8 +8,10 @@ itsdangerous==0.24
 Jinja2==2.9.6
 MarkupSafe==1.0
 packaging==16.8
+pkg-resources==0.0.0
 pycparser==2.17
 pyparsing==2.2.0
+pysodium==0.6.15
 redis==2.10.5
 six==1.10.0
 SQLAlchemy==1.1.9

--- a/run.py
+++ b/run.py
@@ -1,4 +1,6 @@
 from ctf import create_app
 import os
 app = create_app()
-app.run(debug=True, port=int(os.environ.get('PORT', '5000')))
+app.run(debug=True,
+        host=os.environ.get('HOST', '127.0.0.1'),
+        port=int(os.environ.get('PORT', '5000')))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -80,9 +80,9 @@ def test_user_auth(app):
         create_user('test', 'badpw', 409, 'That username is taken.')
 
         # Login
-        login('abc', 'badpw', 403, 'Incorrect username or password.')
-        login('test', 'badpw', 403, 'Incorrect username or password.')
-        login('test', 'test', 403, 'Incorrect username or password.')
+        login('abc', 'badpw', 403, 'Incorrect password.')
+        login('test', 'badpw', 403, 'Incorrect password.')
+        login('test', 'test', 403, 'Incorrect password.')
 
         data = login('test', 'test😊', 201)
         key = data['key']

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -182,7 +182,7 @@ def test_login_incorrect(client, username, password):
     form_data = {'username': username, 'password': password}
     rv = client.post('/login/', data=form_data)
     assert rv.status_code == 403
-    assert b'Incorrect username or password.' in rv.data
+    assert b'Incorrect password.' in rv.data
 
 
 def test_home(client, team_data):


### PR DESCRIPTION
Some questions people might have about this PR:

#### Why Not argon_cffi?
argon_cffi is an immensely heavy package, a large part of this stemming from it's requirement of cffi which in turn requires an ENTIRE C COMPILER. This is not cffi's fault, as it is a massive library that is designed for all kinds of C-related things, and argon_cffi uses a very small portion of that. Still, it adds a lot of weight to the application which is designed to be quite lightweight. Additionally, argon_cffi uses it's own version of argon2, and I would trust libsodium more than it any day of the week given libsodium's current popularity.

#### Why pysodium?
pysodium is a very simple program, pretty much just making calls directly into libsodium. This means that any issues that may arise in the library will be derivative of libsodium, and thus we can rely on libsodium's team to properly patch and maintain it, without being too worried about if this python library will continue to be maintained.

#### Why INTERACTIVE mode for argon2?
After running benchmarks for all three modes, the decision simply came out of usability. In even MODERATE mode, the application slowed to a crawl and response times could be felt to be slower. Additionally, the build and test cycle became equally painful, and since Argon2 is a perfectly fine hashing strategy for the time being, I feel it's safe to keep in interactive mode.

#### Why did you remove the anti-username discovery code?
If people want to discover usernames, they can just try to sign up for that account and if it says "this username is already taken", then the username has been discovered.